### PR TITLE
Apply mixins for Tags and Categories pages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import VueIcon from "vue-icon";
 import VueProgressBar from "vue-progressbar";
 
-// import VueSimpleAccordion from "vue-simple-accordion";
+import VueSimpleAccordion from "vue-simple-accordion";
 
 // Import typefaces
 import "typeface-montserrat";
@@ -43,7 +43,7 @@ export default function (Vue, { router, head, isClient, appOptions }) {
     autoFinish: false
   });
 
-  //  Vue.use(VueSimpleAccordion, {});
+  Vue.use(VueSimpleAccordion, {});
 
   router.beforeEach((to, from, next) => {
     Vue.prototype.$Progress.start();

--- a/src/pages/Categories.vue
+++ b/src/pages/Categories.vue
@@ -114,24 +114,17 @@ query pathInfo {
 <script>
 import dayjs from "dayjs";
 
-import {
-  VsaList,
-  VsaItem,
-  VsaHeading,
-  VsaContent,
-  VsaIcon
-} from "vue-simple-accordion";
+import seoMixin from "~/vue-utils/mixins/seo";
+import routerMixin from "~/vue-utils/mixins/router";
+
 import BlogInfo from "~/components/widgets/BlogInfo";
 
 export default {
   components: {
-    VsaList,
-    VsaItem,
-    VsaHeading,
-    VsaContent,
-    VsaIcon,
     BlogInfo
   },
+
+  mixins: [seoMixin, routerMixin],
 
   computed: {
     categories() {
@@ -158,6 +151,10 @@ export default {
       }
       return dayjs(rawDate).format("HH:mm-DD/MM/YYYY");
     }
+  },
+
+  metaInfo() {
+    return this.generateMetaInfo({ siteTitle: "All Categories" });
   }
 };
 </script>

--- a/src/pages/Tags.vue
+++ b/src/pages/Tags.vue
@@ -111,24 +111,17 @@ query pathInfo {
 <script>
 import dayjs from "dayjs";
 
-import {
-  VsaList,
-  VsaItem,
-  VsaHeading,
-  VsaContent,
-  VsaIcon
-} from "vue-simple-accordion";
+import seoMixin from "~/vue-utils/mixins/seo";
+import routerMixin from "~/vue-utils/mixins/router";
+
 import BlogInfo from "~/components/widgets/BlogInfo";
 
 export default {
   components: {
-    VsaList,
-    VsaItem,
-    VsaHeading,
-    VsaContent,
-    VsaIcon,
     BlogInfo
   },
+
+  mixins: [seoMixin, routerMixin],
 
   computed: {
     tags() {
@@ -159,6 +152,10 @@ export default {
       }
       return dayjs(rawDate).format("HH:mm-DD/MM/YYYY");
     }
+  },
+
+  metaInfo() {
+    return this.generateMetaInfo({ siteTitle: "All Tags" });
   }
 };
 </script>


### PR DESCRIPTION
## Proposed Changes

- Apply mixins for Tags and Categories pages.
- Generate metainfo for Tags and Categories pages.
- Import vue-accordion globally.